### PR TITLE
Updating model's url

### DIFF
--- a/analyze_visual/object_detection/generic_model.py
+++ b/analyze_visual/object_detection/generic_model.py
@@ -46,8 +46,8 @@ class SsdNvidia:
         self.use_cuda = torch.cuda.is_available()
         self.device = torch.device("cuda:0" if self.use_cuda else "cpu")
         print("Using:", self.device)
-        checkpoint_str =\
-            'https://api.ngc.nvidia.com/v2/models/nvidia/ssdpyt_fp32/versions/1/files/nvidia_ssdpyt_fp32_20190225.pt'
+        checkpoint_str = \
+            'https://api.ngc.nvidia.com/v2/models/nvidia/ssd_pyt_ckpt_amp/versions/19.09.0/files/nvidia_ssdpyt_fp16_190826.pt'
 
         # fix torch hub's code problem with empty frames
         # !!!if the code gets updated, remove these lines!!!


### PR DESCRIPTION
Fixes #25.

The previous model we used was deleted by Nvidia. A new one is used as discussed here: https://github.com/NVIDIA/DeepLearningExamples/issues/721 and solved here https://github.com/NVIDIA/DeepLearningExamples/pull/727

For us, a link replacement was needed.  